### PR TITLE
[CHORE] 예전 홈 `/wp`로 접근 시 홈으로 리다이렉트 시키기 

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,10 +1,18 @@
 import styled from '@emotion/styled';
 import Sopt404 from '@src/assets/images/sopt_404.png';
+import RoundButton from '@src/components/common/RoundButton';
 import theme from '@src/styles/theme';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import React from 'react';
 
-function wrong() {
+function Wrong() {
+  const router = useRouter();
+
+  const handleButtonClick = () => {
+    router.push('/');
+  };
+
   return (
     <Styled.Root>
       <Image
@@ -16,11 +24,12 @@ function wrong() {
         placeholder="blur"
       />
       <span>잘못된 경로예요!</span>
+      <RoundButton onClick={handleButtonClick}>홈으로 가기</RoundButton>
     </Styled.Root>
   );
 }
 
-export default wrong;
+export default Wrong;
 
 const Styled = {
   Root: styled.section`
@@ -32,6 +41,7 @@ const Styled = {
     height: 100vh;
     & span {
       margin-top: 99px;
+      margin-bottom: 20px;
       line-height: 56px;
       color: ${theme.colors.soptWhite};
       font-family: 'SUIT';

--- a/src/pages/wp.tsx
+++ b/src/pages/wp.tsx
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/router';
+import React, { useEffect } from 'react';
+
+function LegacyHomePage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.push('/');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return <></>;
+}
+
+export default LegacyHomePage;


### PR DESCRIPTION
## 📝 PR 요약

**[예전 홈 `/wp`로 접근 시 홈으로 리다이렉트 시키기]**

- 이전 `sopt.org`가 워드프레스로 제작되었어서, 구글 주소창에 `sopt.org`를 입력하면 `sopt.org/wp`로 자동완성을 해줘서 다시 `/wp`를 지워서 접근해야하는 불편함이 있었어요.
- 그래서 `sopt.org/wp`로 자동완성이 되더라도 알아서 홈으로 리다이렉트되도록 해주었어요.

**[404페이지에 `홈으로 가기` 버튼 추가]**

- 현재 404페이지에는 홈으로 갈 수 있는 버튼이 없어서, 기존 버튼 컴포넌트를 활용해 `홈으로 가기` 버튼을 임의로 하나 추가해줬어요.

<br/>

## 📸 ScreenShot

<img src="https://user-images.githubusercontent.com/28650320/185775304-d0f00bbd-be78-4461-a6d8-2d3ed608a0ec.png" width=80% />

